### PR TITLE
refill user session variable with last user data on some pages loading

### DIFF
--- a/controller/Controller.php
+++ b/controller/Controller.php
@@ -30,6 +30,9 @@ class Controller
 
     {
         if (isset($_SESSION['user']) && !empty($_SESSION['user'])) {
+            $userManager = new UserManager();
+            $_SESSION['user'] = new User($userManager->getUser($_SESSION['user']->getIdentifier()));
+
             $this->set('title', 'Les Sardines');
             $this->set('css', array('donner'));
             $this->render('view/donner.php');
@@ -45,6 +48,9 @@ class Controller
     public function instructionsView()
 
     {
+        $userManager = new UserManager();
+        $_SESSION['user'] = new User($userManager->getUser($_SESSION['user']->getIdentifier()));
+
         $this->set('title', 'Donner');
         $this->set('css', array('stand'));
         $this->render('view/stand.php');
@@ -65,6 +71,9 @@ class Controller
     public function mentions()
 
     {
+        $userManager = new UserManager();
+        $_SESSION['user'] = new User($userManager->getUser($_SESSION['user']->getIdentifier()));
+
         $this->set('title', 'Mentions légales');
         $this->set('css', array('standard'));
         $this->render('view/mentions.php');

--- a/controller/Controller.php
+++ b/controller/Controller.php
@@ -10,6 +10,10 @@ class Controller
     private $vars = array();
     private $rendered = false;
 
+    private function refreshUser() {
+        $userManager = new UserManager();
+        $_SESSION['user'] = new User($userManager->getUser($_SESSION['user']->getIdentifier()));
+    }
 
     #---------
     #  INDEX
@@ -30,8 +34,7 @@ class Controller
 
     {
         if (isset($_SESSION['user']) && !empty($_SESSION['user'])) {
-            $userManager = new UserManager();
-            $_SESSION['user'] = new User($userManager->getUser($_SESSION['user']->getIdentifier()));
+            $this->refreshUser();
 
             $this->set('title', 'Les Sardines');
             $this->set('css', array('donner'));
@@ -48,8 +51,7 @@ class Controller
     public function instructionsView()
 
     {
-        $userManager = new UserManager();
-        $_SESSION['user'] = new User($userManager->getUser($_SESSION['user']->getIdentifier()));
+        $this->refreshUser();
 
         $this->set('title', 'Donner');
         $this->set('css', array('stand'));
@@ -71,8 +73,7 @@ class Controller
     public function mentions()
 
     {
-        $userManager = new UserManager();
-        $_SESSION['user'] = new User($userManager->getUser($_SESSION['user']->getIdentifier()));
+        $this->refreshUser();
 
         $this->set('title', 'Mentions légales');
         $this->set('css', array('standard'));
@@ -102,16 +103,17 @@ class Controller
                 $userManager = new UserManager();
                 $avatar = $userManager->findAvatar();
                 if (strtolower($userManager->getIdByIdentifier($_SESSION['user'])) == strtolower($_SESSION['user']->getId_user())) {
-                    $user = new User($userManager->getUser($_SESSION['user']->getIdentifier()));
-                    $this->set('title', 'Mon compte');
-                    $this->set('user', $user);
-                    if (isset($avatar) && !empty($avatar)) {
+
+                    $this->refreshUser();
+                    
+                    if (isset($avatar) && !empty($avatar))
                         $this->set('avatar', $avatar);
-                    }
-                    $css = array('profil');
-                    $this->set('css', $css);
+
                     $this->set('update',$updateAccount);
+                    $this->set('title', 'Mon compte');
+                    $this->set('css', array('profil'));
                     $this->render('view/profil.php');
+                    
                 }
             } else {
                 header('Location: ' . Config::$root . 'donner');

--- a/view/profil.php
+++ b/view/profil.php
@@ -1,9 +1,5 @@
 <main>
 
-
-    <!-- je mets les champs brut sans me soucier du layout, il suffira de les copier/coller où il faut -->
-    <!-- je suppose que les valeurs seront récupérées dans l'objet user et pas dans la session -->
-
     <!--<div id="avatar-field">-->
     <?php #if(!empty($user->getAvatar())): ?>
     <!--<div id="avatar" style="background-image: url('../css/img/<?php #echo $user->getAvatar(); ?>');"></div>-->
@@ -42,30 +38,30 @@
                            value="<?php if(!empty($update['error_msg'])){
                                echo $update['pseudo'];
                            }else{
-                            echo $user->getNickname();
+                            echo $_SESSION['user']->getNickname();
                            }
                        ?>"/>
                 </div>
                 <p id="pseudo-info"><?= $update['error_msg'];?></p>
             </div>
             <div class="right-box">
-                <p>ID : <?= $user->getIdentifier(); ?></p>
+                <p>ID : <?= $_SESSION['user']->getIdentifier(); ?></p>
                 <p>Solde Sardines : </p>
-                <p> <?= $user->getBalance(); ?> </p>
+                <p> <?= $_SESSION['user']->getBalance(); ?> </p>
             </div>
         </div>
 
         <div class="under-box">
-            <p>Email : <?= $user->getEmail(); ?></p>
-            <p>Date de création du compte : <?= $user->getAccount_creation_date(); ?>
-            <p>Dernière connexion : <?= $user->getLast_Login(); ?></p>
+            <p>Email : <?= $_SESSION['user']->getEmail(); ?></p>
+            <p>Date de création du compte : <?= $_SESSION['user']->getAccount_creation_date(); ?>
+            <p>Dernière connexion : <?= $_SESSION['user']->getLast_Login(); ?></p>
             <?php
-            if ($user->getStaff() OR $user->getAdmin()):
+            if ($_SESSION['user']->getStaff() OR $_SESSION['user']->getAdmin()):
                 ?>
-                <?php if ($user->getStaff()): ?>
+                <?php if ($_SESSION['user']->getStaff()): ?>
                 <p>Vous êtes membre interne des Sardines.</p>
             <?php endif; ?>
-                <?php if ($user->getAdmin()): ?>
+                <?php if ($_SESSION['user']->getAdmin()): ?>
                 <p>Vous êtes administrateur.</p>
             <?php endif; ?>
             <?php endif; ?>


### PR DESCRIPTION
Le compte de sardines ne s'actualisait pas tant que l'user ne se déco/reconnectait pas parce que ses valeurs n'étaient pas réassignées dans la variable session.
Cette valeur est maintenant récupérée sur toutes les pages auxquelles un user connecté peut accéder.