### PR TITLE
Fix signin submit

### DIFF
--- a/js/signin_login_validation.js
+++ b/js/signin_login_validation.js
@@ -74,7 +74,6 @@ if (confirm != null) {
 // is conditions générales acceptées
 if (disc != null) {
     disc.addEventListener('click', function(e) {
-        console.log(this.checked);
         enable();
     });
 }

--- a/js/signin_login_validation.js
+++ b/js/signin_login_validation.js
@@ -73,8 +73,9 @@ if (confirm != null) {
 
 // is conditions générales acceptées
 if (disc != null) {
-    disc.addEventListener('input', function(e) {
-            enable();
+    disc.addEventListener('click', function(e) {
+        console.log(this.checked);
+        enable();
     });
 }
 


### PR DESCRIPTION
L'évènement input est apparemment "mal compatible" sur safari mobile (décocher la checkbox ne déclenche pas d'évènement).
Il est remplacer par un évènement click qui fonctionne.